### PR TITLE
fix: Bitrise fails with the error error: unknown option '--version'

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3,7 +3,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
-  - STEP_VERSION: 1.0.3
+  - STEP_VERSION: 1.0.4
   
   - SAMPLE_APP_PATH: $SAMPLE_APP_PATH
   - SAMPLE_APP_URL: https://github.com/bitrise-samples/react-native-sample.git

--- a/step.sh
+++ b/step.sh
@@ -99,7 +99,9 @@ if [ ! -z "${binary_path}" ] ; then
     REACT_NATIVE_BIN="${binary_path}/react-native"
 fi
 
-$REACT_NATIVE_BIN --version
+if ! $REACT_NATIVE_BIN --version 2>/dev/null ; then
+    $REACT_NATIVE_BIN -v
+fi
 
 echo
 


### PR DESCRIPTION
Resolves: #19 
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
1.0.4

### Context

Bitrise fails with the error error: unknown option '--version'

Latest React Native CLI (which is a depencency of RN 0.70) [changed](https://github.com/react-native-community/cli/commit/be3cb6a9fce4eaecfa62179221edf7e4201c89cc#diff-deba09a4756b9e0a476134a25f95b8b0d9320bcd51436f146312daf1a930d8c9L7) --version to -v.

### Changes

If the --version command exists, it will simply display the command out. 
If it does not, ignore the error output and print the -v command result.