### PR TITLE
Fallback to `npx react-native` if `binary_path` not provided

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -45,9 +45,9 @@ workflows:
             set -v
 
             git clone $SAMPLE_APP_URL .
-    - install-react-native@0.1.0:
+    - install-react-native:
         run_if: .IsCI
-    - npm@0.1.1:
+    - npm:
         inputs:
         - command: install
     - path::./:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,10 +1,9 @@
-format_version: 1.3.1
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
   envs:
   - STEP_VERSION: 1.0.4
-  
   - SAMPLE_APP_PATH: $SAMPLE_APP_PATH
   - SAMPLE_APP_URL: https://github.com/bitrise-samples/react-native-sample.git
 
@@ -15,7 +14,7 @@ workflows:
     steps:
     - change-workdir:
         title: Switch working dir
-        run_if: true
+        run_if: "true"
         inputs:
         - path: $SAMPLE_APP_PATH
     - path::./:
@@ -34,7 +33,7 @@ workflows:
             rm -rf ./_tmp
     - change-workdir:
         title: Switch working dir to test / _tmp dir
-        run_if: true
+        run_if: "true"
         inputs:
         - path: ./_tmp
         - is_create_path: true
@@ -46,7 +45,7 @@ workflows:
             set -v
 
             git clone $SAMPLE_APP_URL .
-    - install-react-native@0.1.0: 
+    - install-react-native@0.1.0:
         run_if: .IsCI
     - npm@0.1.1:
         inputs:
@@ -63,7 +62,6 @@ workflows:
     - RELEASE_VERSION: $STEP_VERSION
     steps:
     - script:
-        title:
         inputs:
         - content: |
             #!/bin/bash
@@ -86,10 +84,10 @@ workflows:
   share-this-step:
     envs:
       # if you want to share this step into a StepLib
-      - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
-      - STEP_ID_IN_STEPLIB: react-native-bundle
-      - STEP_GIT_VERION_TAG_TO_SHARE: $STEP_VERSION
-      - STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/steps-react-native-bundle.git
+    - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
+    - STEP_ID_IN_STEPLIB: react-native-bundle
+    - STEP_GIT_VERION_TAG_TO_SHARE: $STEP_VERSION
+    - STEP_GIT_CLONE_URL: https://github.com/bitrise-steplib/steps-react-native-bundle.git
     description: |-
       If this is the first time you try to share a Step you should
       first call: $ bitrise share

--- a/step.sh
+++ b/step.sh
@@ -101,7 +101,7 @@ if [[ -n "$binary_path" ]]; then
 	REACT_NATIVE_BIN="$binary_path/react-native"
 elif output=$(npx which react-native); then
 	# If npx version is available, use that
-	REACT_NATIVE_BIN=$(dirname $output)
+	REACT_NATIVE_BIN=$output
 else
 	# Otherwise, use the react-native CLI in the current PATH
 	REACT_NATIVE_BIN="react-native"

--- a/step.sh
+++ b/step.sh
@@ -101,9 +101,9 @@ if [[ -n "${binary_path}" ]]; then
 	REACT_NATIVE_BIN="${binary_path}/react-native"
 	echo_details "* Using binary specified in binary_path"
 	echo_details "* Location: ${REACT_NATIVE_BIN}"
-elif output=$(npx which react-native 2>/dev/null); then
+elif output=$(npx --yes which react-native 2>/dev/null); then
 	# If npx version is available, use that
-	REACT_NATIVE_BIN=$output
+	REACT_NATIVE_BIN=${output}
 	echo_details "* Using binary via \`npx\`"
 	echo_details "* Location: ${REACT_NATIVE_BIN}"
 else

--- a/step.sh
+++ b/step.sh
@@ -94,9 +94,17 @@ echo_details "* url: $url"
 
 echo_info "react-native version:"
 
-REACT_NATIVE_BIN="react-native"
-if [ ! -z "${binary_path}" ] ; then
-    REACT_NATIVE_BIN="${binary_path}/react-native"
+# Find path to the react-native CLI
+declare REACT_NATIVE_BIN
+if [[ -n "$binary_path" ]]; then
+	# If binary_path is specified, use that
+	REACT_NATIVE_BIN="$binary_path/react-native"
+elif output=$(npx which react-native); then
+	# If npx version is available, use that
+	REACT_NATIVE_BIN=$(dirname $output)
+else
+	# Otherwise, use the react-native CLI in the current PATH
+	REACT_NATIVE_BIN="react-native"
 fi
 
 if ! $REACT_NATIVE_BIN --version 2>/dev/null ; then

--- a/step.sh
+++ b/step.sh
@@ -100,18 +100,16 @@ if [[ -n "${binary_path}" ]]; then
 	# If binary_path is specified, use that
 	REACT_NATIVE_BIN="${binary_path}/react-native"
 	echo_details "* Using binary specified in binary_path"
-	echo_details "* Location: ${REACT_NATIVE_BIN}"
 elif output=$(npx --yes which react-native 2>/dev/null); then
 	# If npx version is available, use that
 	REACT_NATIVE_BIN=${output}
 	echo_details "* Using binary via \`npx\`"
-	echo_details "* Location: ${REACT_NATIVE_BIN}"
 else
 	# Otherwise, use the react-native CLI in the current PATH
 	REACT_NATIVE_BIN="react-native"
 	echo_details "* Using react-native CLI in PATH"
-	echo_details "* Location: ${REACT_NATIVE_BIN}"
 fi
+echo_details "* Location: ${REACT_NATIVE_BIN}"
 
 if output=$("${REACT_NATIVE_BIN}" --version 2>/dev/null); then
 	echo_details "* Version: ${output}"

--- a/step.sh
+++ b/step.sh
@@ -92,23 +92,33 @@ echo_info "Deprecated Configs:"
 echo_details "* root: $root"
 echo_details "* url: $url"
 
-echo_info "react-native version:"
+echo_info "\`react-native\` info:"
 
 # Find path to the react-native CLI
 declare REACT_NATIVE_BIN
-if [[ -n "$binary_path" ]]; then
+if [[ -n "${binary_path}" ]]; then
 	# If binary_path is specified, use that
-	REACT_NATIVE_BIN="$binary_path/react-native"
-elif output=$(npx which react-native); then
+	REACT_NATIVE_BIN="${binary_path}/react-native"
+	echo_details "* Using binary specified in binary_path"
+	echo_details "* Location: ${REACT_NATIVE_BIN}"
+elif output=$(npx which react-native 2>/dev/null); then
 	# If npx version is available, use that
 	REACT_NATIVE_BIN=$output
+	echo_details "* Using binary via \`npx\`"
+	echo_details "* Location: ${REACT_NATIVE_BIN}"
 else
 	# Otherwise, use the react-native CLI in the current PATH
 	REACT_NATIVE_BIN="react-native"
+	echo_details "* Using react-native CLI in PATH"
+	echo_details "* Location: ${REACT_NATIVE_BIN}"
 fi
 
-if ! $REACT_NATIVE_BIN --version 2>/dev/null ; then
-    $REACT_NATIVE_BIN -v
+if output=$("${REACT_NATIVE_BIN}" --version 2>/dev/null); then
+	echo_details "* Version: ${output}"
+elif output=$("${REACT_NATIVE_BIN}" -v 2>/dev/null); then
+	echo_details "* Version: ${output}"
+else
+	echo_warn "* Failed to get \`react-native\` version"
 fi
 
 echo


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

Best practice these days is to use `npx` to run node modules within a project, rather than installing them globally. This change falls back to using the `react-native` binary used by `npx` before attempting to use a globally installed version.

### Changes

- Add an `if` check for a locally installed version of `react-native` using `npx`
- Cleanup `bitrise.yml` file

## Testing

I've been testing these changes while building out the workflow for the new [React Native sample app built for the PLG team](https://github.com/bitrise-io/getting-started-react-native-sample-app), and it's working as expected.